### PR TITLE
allow ERB in database.yml

### DIFF
--- a/lib/migreazy.rb
+++ b/lib/migreazy.rb
@@ -5,7 +5,7 @@ module Migreazy
   
   def self.ensure_db_connection
     unless @@db_connected
-      db_config = YAML::load(IO.read("./config/database.yml"))
+      db_config = YAML.load(ERB.new(File.read('./config/database.yml')).result)
       ActiveRecord::Base.establish_connection db_config['development']
       @@db_connected = true
     end


### PR DESCRIPTION
thanks for the gem ... super useful! 

we use ENV vars to populate the database.yml file which are expressed in ERB snippets.

I just wrapped the reading of the database.yml file into an ERB.new(file).result and then load it to yaml. It might help a few people :) 

